### PR TITLE
Refactor: Removed environment variable loading from file

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,17 +6,15 @@ import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
-import { getEnvPath } from './common/helper/env.helper';
-// import { envValidation } from './common/helper/env.validation';
+import { envValidation } from './common/helper/env.validation';
 import { UserModule } from './user/user.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      // envFilePath: getEnvPath(`${__dirname}/..`),
       cache: true,
-      // validate: envValidation,
+      validate: envValidation,
     }),
     MikroOrmModule.forRoot(),
     AuthModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,16 +7,16 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { getEnvPath } from './common/helper/env.helper';
-import { envValidation } from './common/helper/env.validation';
+// import { envValidation } from './common/helper/env.validation';
 import { UserModule } from './user/user.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      envFilePath: getEnvPath(`${__dirname}/..`),
+      // envFilePath: getEnvPath(`${__dirname}/..`),
       cache: true,
-      validate: envValidation,
+      // validate: envValidation,
     }),
     MikroOrmModule.forRoot(),
     AuthModule,

--- a/src/common/helper/env.validation.ts
+++ b/src/common/helper/env.validation.ts
@@ -8,20 +8,7 @@ import {
   validateSync,
 } from 'class-validator';
 
-const development = 'development';
-const production = 'production';
-const test = 'test';
-
-const nodeEnvironment = {
-  [development]: development,
-  [production]: production,
-  [test]: test,
-};
-
 export class EnvironmentVariables {
-  @IsEnum(nodeEnvironment)
-  NODE_ENV: keyof typeof nodeEnvironment;
-
   @IsString()
   DB_NAME: string;
 


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] Refactoring (no functional changes, no api changes)

## For what purpose

k8s configmap으로 env관리를 하게 되면서, 특정 파일에서 env를 로딩하는 로직이 불필요해짐

## Key changes

1. 환경별로 상이한 특정 경로에서 env파일을 조회하는 로직 삭제

## To reviewers

configmap 에 오류가 있을 경우를 대비해  env validation은 유지하고
env를 파일에서 불러오는 로직만 제거했습니다 ~

## Screenshots
