### PR TITLE
Fix/add-enum-name: Native enum name 빼먹어서, 넣어줬어요

### DIFF
--- a/src/migrations/.snapshot-postgres.json
+++ b/src/migrations/.snapshot-postgres.json
@@ -47,6 +47,11 @@
           "name": "user_role",
           "schema": "public",
           "items": ["USER", "ADMIN"]
+        },
+        "user-map-role": {
+          "name": "user-map-role",
+          "schema": "public",
+          "items": ["ADMIN", "READ", "WRITE"]
         }
       }
     },
@@ -144,6 +149,11 @@
           "name": "user_role",
           "schema": "public",
           "items": ["USER", "ADMIN"]
+        },
+        "user-map-role": {
+          "name": "user-map-role",
+          "schema": "public",
+          "items": ["ADMIN", "READ", "WRITE"]
         }
       }
     },
@@ -169,11 +179,12 @@
         },
         "role": {
           "name": "role",
-          "type": "text[]",
+          "type": "user-map-role[]",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "nativeEnumName": "user-map-role",
           "default": "'{READ,WRITE}'",
           "enumItems": ["ADMIN", "READ", "WRITE"],
           "mappedType": "array"
@@ -220,6 +231,11 @@
           "name": "user_role",
           "schema": "public",
           "items": ["USER", "ADMIN"]
+        },
+        "user-map-role": {
+          "name": "user-map-role",
+          "schema": "public",
+          "items": ["ADMIN", "READ", "WRITE"]
         }
       }
     }
@@ -234,6 +250,11 @@
       "name": "user_role",
       "schema": "public",
       "items": ["USER", "ADMIN"]
+    },
+    "user-map-role": {
+      "name": "user-map-role",
+      "schema": "public",
+      "items": ["ADMIN", "READ", "WRITE"]
     }
   }
 }

--- a/src/migrations/Migration20240625032357.ts
+++ b/src/migrations/Migration20240625032357.ts
@@ -1,13 +1,16 @@
 import { Migration } from '@mikro-orm/migrations';
 
-export class Migration20240624105844 extends Migration {
+export class Migration20240625032357 extends Migration {
   async up(): Promise<void> {
+    this.addSql(
+      "create type \"user-map-role\" as enum ('ADMIN', 'READ', 'WRITE');",
+    );
     this.addSql(
       'create table "map" ("id" varchar(255) not null, "name" varchar(255) not null, constraint "map_pkey" primary key ("id"));',
     );
 
     this.addSql(
-      'create table "user_map" ("user_id" int not null, "map_id" varchar(255) not null, "role" text[] not null default \'{READ,WRITE}\', constraint "user_map_pkey" primary key ("user_id", "map_id"));',
+      'create table "user_map" ("user_id" int not null, "map_id" varchar(255) not null, "role" "user-map-role"[] not null default \'{READ,WRITE}\', constraint "user_map_pkey" primary key ("user_id", "map_id"));',
     );
 
     this.addSql(
@@ -26,5 +29,7 @@ export class Migration20240624105844 extends Migration {
     this.addSql('drop table if exists "map" cascade;');
 
     this.addSql('drop table if exists "user_map" cascade;');
+
+    this.addSql('drop type "user-map-role";');
   }
 }

--- a/src/user-map/entities/user-map.entity.ts
+++ b/src/user-map/entities/user-map.entity.ts
@@ -30,6 +30,7 @@ export class UserMap {
     items: () => UserMapRole,
     array: true,
     default: [UserMapRole.READ, UserMapRole.WRITE],
+    nativeEnumName: 'user-map-role',
   })
   role: (typeof UserMapRole)[keyof typeof UserMapRole];
 


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Refactoring (no functional changes, no api changes)

## For what purpose

Mikro orm 에서 enum 설정할 때, native enum name 항목 빼먹으면 db에 enum타입이 아니라 그냥 text로 들어가더라구요.

그래서  수정했어요

## Key changes

1. Add native enum name

## To reviewers

## Screenshots
<img width="348" alt="image" src="https://github.com/mash-up-kr/VitaminC_server/assets/71132893/cf17165b-333e-4e4c-aef4-bb76a165ef17">
