### PR TITLE
Chore: Set swagger authorization header

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, InternalServerErrorException } from '@nestjs/common';
+import { ApiBearerAuth } from '@nestjs/swagger';
 
 import { AppService } from './app.service';
 import { UseAuthGuard } from './common/decorators/auth-guard.decorator';
@@ -18,6 +19,7 @@ export class AppController {
 
   @Get('/me')
   @UseAuthGuard([UserRole.USER])
+  @ApiBearerAuth()
   getMe(@CurrentUser() user: User): User {
     return user;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Korrk API')
     .setDescription('Mashup의 VitaminC팀 API 서버입니다')
+    .addBearerAuth()
     .build();
 
   const document = SwaggerModule.createDocument(app, config);

--- a/src/map/map.controller.ts
+++ b/src/map/map.controller.ts
@@ -8,7 +8,12 @@ import {
   Patch,
   Post,
 } from '@nestjs/common';
-import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 
 import { UseAuthGuard } from '../common/decorators/auth-guard.decorator';
 import { CurrentUser } from '../common/decorators/user.decorator';
@@ -49,6 +54,7 @@ export class MapController {
 
   @Get(':id')
   @ApiOkResponse({ type: MapResponseDto })
+  @ApiBearerAuth()
   findOne(@Param('id') id: string) {
     // TODO: findOne For user로 만들어서 (ADMIN, READ, WRITE)권한없으면 403을 반환하는 라우트를 만들어야 합니다.
     return this.mapService.findOne({ id });
@@ -56,12 +62,14 @@ export class MapController {
 
   @Patch(':id')
   @ApiOkResponse({ type: MapResponseDto })
+  @ApiBearerAuth()
   update(@Param('id') id: string, @Body() updateMapDto: UpdateMapDto) {
     return this.mapService.update(id, updateMapDto);
   }
 
   @Delete(':id')
   @ApiOkResponse({ type: Number })
+  @ApiBearerAuth()
   remove(@Param('id') id: string) {
     return this.mapService.remove(id);
   }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -7,7 +7,7 @@ import {
   Patch,
   Query,
 } from '@nestjs/common';
-import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOkResponse, ApiTags } from '@nestjs/swagger';
 
 import { UseAuthGuard } from 'src/common/decorators/auth-guard.decorator';
 import { CurrentUser } from 'src/common/decorators/user.decorator';
@@ -25,6 +25,7 @@ export class UserController {
   @Get(':id')
   @UseAuthGuard([UserRole.USER])
   @ApiOkResponse({ type: UserResponseDto })
+  @ApiBearerAuth()
   async findOne(@Param('id') id: string) {
     const user = await this.userService.findOne({ id: +id });
     return user;
@@ -33,6 +34,7 @@ export class UserController {
   @Patch()
   @UseAuthGuard([UserRole.USER])
   @ApiOkResponse({ type: UserResponseDto })
+  @ApiBearerAuth()
   async update(
     @Body() updateUserDto: UpdateUserRequestDto,
     @CurrentUser() user: User,
@@ -42,6 +44,7 @@ export class UserController {
 
   @Delete(':id')
   @ApiOkResponse({ type: Number })
+  @ApiBearerAuth()
   async remove(@Param('id') id: string) {
     return this.userService.remove(+id);
   }


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] Refactoring (no functional changes, no api changes)

## For what purpose

- 인증이 필요한 API를 스웨거에서 테스트 가능하게 하기 위함

## Key changes

- 스웨거에서 인증 헤더 설정할 수 있도록 옵션 추가

## To reviewers

- 인증이 필요한 컨트롤러 메소드에 `@ApiBearerAuth()` 설정 필요
- https://docs.nestjs.com/openapi/security#bearer-authentication

## Screenshots

![image](https://github.com/mash-up-kr/VitaminC_server/assets/43634786/f43b05ee-db56-4f59-9f17-a2d1aefe09d8)
