### PR TITLE
Feat : 초대링크 생성 API 구현, 지도 생성/수정/조회 API 추가 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start:dev": "export NODE_ENV=development&& nest start --watch",
     "start:stage": "export NODE_ENV=stage&& nest start --watch",
     "start:prod": "export NODE_ENV=production&& node dist/main",
-    "start:debug": "nest start --debug --watch",
+    "start:debug": "export NODE_ENV=development&& nest start --debug --watch",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule } from '@nestjs/config';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 
 import { LoggerMiddleware } from 'src/core/intercepters/logging.interceptor';
+import { InviteLinkModule } from 'src/invite-link/invite-link.module';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -36,6 +37,7 @@ import { UtilModule } from './util/util.module';
     SearchModule,
     UtilModule,
     PlaceModule,
+    InviteLinkModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Redirect, Res, UseGuards } from '@nestjs/common';
+import { Controller, Get, Res, UseGuards } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ApiTags } from '@nestjs/swagger';
 
@@ -6,7 +6,6 @@ import { Response } from 'express';
 
 import { KakaoInfo } from 'src/common/decorators/kakao-info.decorator';
 import { KakaoGuard } from 'src/common/guards/kakao.guard';
-import { NODE_ENVIRONMENT } from 'src/common/helper/env.validation';
 import { UserProvider } from 'src/entities';
 
 import { AuthService } from './auth.service';

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,3 +1,4 @@
 export const IS_DEV = process.env.NODE_ENV === 'development';
 export const IS_STAGE = process.env.NODE_ENV === 'stage';
 export const IS_PROD = process.env.NODE_ENV === 'production';
+export const INVITE_LINK_EXPIRATION_DAYS = 7;

--- a/src/common/decorators/map-role-guard.decorator.ts
+++ b/src/common/decorators/map-role-guard.decorator.ts
@@ -1,0 +1,20 @@
+import { SetMetadata, UseGuards, applyDecorators } from '@nestjs/common';
+
+import { UserMapRole, UserMapRoleValueType } from 'src/entities';
+
+import { MapRoleGuard } from '../guards/map-role.guard';
+
+export const UseMapRoleGuard = (
+  roles?: UserMapRoleValueType[] | UserMapRoleValueType,
+) =>
+  applyDecorators(
+    SetMetadata(
+      'map-roles',
+      roles
+        ? Array.isArray(roles)
+          ? roles
+          : [roles]
+        : [UserMapRole.ADMIN, UserMapRole.READ, UserMapRole.WRITE],
+    ),
+    UseGuards(MapRoleGuard),
+  );

--- a/src/common/guards/map-role.guard.ts
+++ b/src/common/guards/map-role.guard.ts
@@ -1,0 +1,48 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { UserMapRole } from 'src/entities';
+import { UserMapService } from 'src/user-map/user-map.service';
+
+@Injectable()
+export class MapRoleGuard implements CanActivate {
+  private readonly mapId: string;
+  constructor(
+    private reflector: Reflector,
+    private readonly userMapService: UserMapService,
+  ) {
+    this.mapId = '';
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const mapRoles = this.reflector.get<string[]>(
+      'map-roles',
+      context.getHandler(),
+    );
+    if (!mapRoles) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    const mapId = request.params.id;
+
+    const hasMapRole = async () => {
+      try {
+        const userMap = await this.userMapService.findOneByUserAndMap(
+          user.id,
+          mapId,
+        );
+        return mapRoles.some((role) => userMap.role?.includes(role));
+      } catch (e) {
+        return false;
+      }
+    };
+
+    return await hasMapRole();
+  }
+
+  private isOnlyAdmin(mapRoles: string[]): boolean {
+    return mapRoles.length === 1 && mapRoles[0] === UserMapRole.ADMIN;
+  }
+}

--- a/src/common/guards/map-role.guard.ts
+++ b/src/common/guards/map-role.guard.ts
@@ -6,13 +6,10 @@ import { UserMapService } from 'src/user-map/user-map.service';
 
 @Injectable()
 export class MapRoleGuard implements CanActivate {
-  private readonly mapId: string;
   constructor(
     private reflector: Reflector,
     private readonly userMapService: UserMapService,
-  ) {
-    this.mapId = '';
-  }
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const mapRoles = this.reflector.get<string[]>(

--- a/src/common/guards/map-role.guard.ts
+++ b/src/common/guards/map-role.guard.ts
@@ -38,8 +38,4 @@ export class MapRoleGuard implements CanActivate {
 
     return await hasMapRole();
   }
-
-  private isOnlyAdmin(mapRoles: string[]): boolean {
-    return mapRoles.length === 1 && mapRoles[0] === UserMapRole.ADMIN;
-  }
 }

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,4 +1,5 @@
 import { GroupMap } from './group-map.entity';
+import { InviteLink } from './invite-link.entity';
 import { KakaoPlace } from './kakao-place.entity';
 import { PlaceForMap } from './place-for-map.entity';
 import { Place } from './place.entity';
@@ -23,6 +24,9 @@ export * from './place-for-map.repository';
 export * from './place.entity';
 export * from './place.repository';
 
+export * from './invite-link.entity';
+export * from './invite-link.repository';
+
 export const entities = [
   User,
   GroupMap,
@@ -30,4 +34,5 @@ export const entities = [
   KakaoPlace,
   Place,
   PlaceForMap,
+  InviteLink,
 ];

--- a/src/entities/invite-link.entity.ts
+++ b/src/entities/invite-link.entity.ts
@@ -1,0 +1,26 @@
+import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+
+import { User } from 'src/entities/user.entity';
+
+import { InviteLinkRepository } from './invite-link.repository';
+
+@Entity({ tableName: 'invite_link', repository: () => InviteLinkRepository })
+export class InviteLink {
+  @PrimaryKey()
+  token: string;
+
+  @ManyToOne(() => User)
+  createdBy: User;
+
+  @Property({ type: 'string' })
+  map_id: string;
+
+  @Property({ type: 'timestamp' })
+  expires_at: Date;
+
+  @Property()
+  createdAt: Date = new Date();
+
+  @Property({ onUpdate: () => new Date() })
+  updatedAt: Date = new Date();
+}

--- a/src/entities/invite-link.entity.ts
+++ b/src/entities/invite-link.entity.ts
@@ -1,5 +1,9 @@
-import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Entity, Enum, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 
+import {
+  UserMapRole,
+  UserMapRoleValueType,
+} from 'src/entities/user-map.entity';
 import { User } from 'src/entities/user.entity';
 
 import { InviteLinkRepository } from './invite-link.repository';
@@ -14,6 +18,10 @@ export class InviteLink {
 
   @Property({ type: 'string' })
   map_id: string;
+
+  @Property({ type: 'string', default: UserMapRole.WRITE })
+  @Enum({ items: [UserMapRole.ADMIN, UserMapRole.READ, UserMapRole.WRITE] })
+  map_role: UserMapRoleValueType;
 
   @Property({ type: 'timestamp' })
   expires_at: Date;

--- a/src/entities/invite-link.repository.ts
+++ b/src/entities/invite-link.repository.ts
@@ -1,0 +1,5 @@
+import { ExtendedEntityRepository } from 'src/common/helper/extended-repository.helper';
+
+import { InviteLink } from './invite-link.entity';
+
+export class InviteLinkRepository extends ExtendedEntityRepository<InviteLink> {}

--- a/src/invite-link/invite-link.module.ts
+++ b/src/invite-link/invite-link.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+
+import { InviteLink } from 'src/entities/index';
+import { InviteLinkService } from 'src/invite-link/invite-link.service';
+import { UserMapModule } from 'src/user-map/user-map.module';
+import { UtilModule } from 'src/util/util.module';
+
+@Module({
+  imports: [MikroOrmModule.forFeature([InviteLink]), UserMapModule, UtilModule],
+  providers: [InviteLinkService],
+  exports: [InviteLinkService],
+})
+export class InviteLinkModule {}

--- a/src/invite-link/invite-link.service.spec.ts
+++ b/src/invite-link/invite-link.service.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { getRepositoryToken } from '@mikro-orm/nestjs';
+
+import { ExtendedEntityRepository } from 'src/common/helper/extended-repository.helper';
+import {
+  MockRepository,
+  MockRepositoryFactory,
+} from 'src/common/helper/mock.helper';
+import {
+  InviteLink,
+  InviteLinkRepository,
+  User,
+  UserRepository,
+} from 'src/entities/index';
+import { UserService } from 'src/user/user.service';
+
+import { InviteLinkService } from './invite-link.service';
+
+type InviteLinkMockRepositoryType = MockRepository<
+  ExtendedEntityRepository<InviteLink>
+>;
+describe('InviteLinkService', () => {
+  let service: InviteLinkService;
+  let mockedRepository: InviteLinkMockRepositoryType;
+
+  beforeEach(async () => {
+    const repositoryToken = getRepositoryToken(User);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InviteLinkService,
+        {
+          provide: repositoryToken,
+          useFactory:
+            MockRepositoryFactory.getMockRepository(InviteLinkRepository),
+        },
+      ],
+    }).compile();
+
+    service = module.get<InviteLinkService>(InviteLinkService);
+    mockedRepository =
+      module.get<InviteLinkMockRepositoryType>(repositoryToken);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/invite-link/invite-link.service.ts
+++ b/src/invite-link/invite-link.service.ts
@@ -29,14 +29,14 @@ export class InviteLinkService {
     await this.inviteLinkRepository.persistAndFlush(inviteLink);
 
     return {
-      invite_link_token: token,
+      inviteLinkToken: token,
     };
   }
 
   private getExpiration(): number {
     const now: Date = new Date();
-    const expirationDate: Date = new Date(
-      now.setDate(now.getDate() + INVITE_LINK_EXPIRATION_DAYS),
+    const expirationDate = new Date(
+      now.getTime() + INVITE_LINK_EXPIRATION_DAYS * 24 * 60 * 60 * 1000,
     );
     return expirationDate.getTime();
   }

--- a/src/invite-link/invite-link.service.ts
+++ b/src/invite-link/invite-link.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+
+import { InjectRepository } from '@mikro-orm/nestjs';
+
+import { INVITE_LINK_EXPIRATION_DAYS } from 'src/common/constants';
+import { InviteLink, InviteLinkRepository, User } from 'src/entities';
+import { InviteLinkResponseDto } from 'src/map/dtos/invite-link-response.dto';
+import { UtilService } from 'src/util/util.service';
+
+@Injectable()
+export class InviteLinkService {
+  constructor(
+    @InjectRepository(InviteLink)
+    private readonly inviteLinkRepository: InviteLinkRepository,
+    private readonly utilService: UtilService,
+  ) {}
+
+  async create(mapId: string, by: User): Promise<InviteLinkResponseDto> {
+    const expiration: number = this.getExpiration();
+    const input: string = `map_id=${mapId}&user_id=${by.id}&expiration=${expiration}`;
+    const token: string = this.utilService.generateMD5TokenWithSalt(input, 5);
+
+    const inviteLink: InviteLink = new InviteLink();
+    inviteLink.token = token;
+    inviteLink.createdBy = by;
+    inviteLink.map_id = mapId;
+    inviteLink.expires_at = new Date(expiration);
+
+    await this.inviteLinkRepository.persistAndFlush(inviteLink);
+
+    return {
+      invite_link_token: token,
+    };
+  }
+
+  private getExpiration(): number {
+    const now: Date = new Date();
+    const expirationDate: Date = new Date(
+      now.setDate(now.getDate() + INVITE_LINK_EXPIRATION_DAYS),
+    );
+    return expirationDate.getTime();
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,10 +8,9 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 // import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import cookieParser from 'cookie-parser';
 
-import { CustomExceptionFilter } from 'src/core/exception-filters/custom-exception.filter';
-import { ResponseInterceptor } from 'src/core/intercepters/response.intercepter';
-
 import { AppModule } from './app.module';
+import { CustomExceptionFilter } from './core/exception-filters/custom-exception.filter';
+import { ResponseInterceptor } from './core/intercepters/response.intercepter';
 import { UtilService } from './util/util.service';
 
 async function bootstrap() {

--- a/src/map/dtos/invite-link-response.dto.ts
+++ b/src/map/dtos/invite-link-response.dto.ts
@@ -2,5 +2,5 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class InviteLinkResponseDto {
   @ApiProperty()
-  invite_link_token: string;
+  inviteLinkToken: string;
 }

--- a/src/map/dtos/invite-link-response.dto.ts
+++ b/src/map/dtos/invite-link-response.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class InviteLinkResponseDto {
+  @ApiProperty()
+  invite_link_token: string;
+}

--- a/src/map/map.controller.spec.ts
+++ b/src/map/map.controller.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
-import { MockService, MockServiceFactory } from 'src/common/helper/mock.helper';
-
+import { MockService, MockServiceFactory } from '../common/helper/mock.helper';
 import { MapController } from './map.controller';
 import { MapService } from './map.service';
 

--- a/src/map/map.controller.ts
+++ b/src/map/map.controller.ts
@@ -12,13 +12,17 @@ import {
   ApiBearerAuth,
   ApiOkResponse,
   ApiOperation,
+  ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 
 import { UseAuthGuard } from '../common/decorators/auth-guard.decorator';
+import { UseMapRoleGuard } from '../common/decorators/map-role-guard.decorator';
 import { CurrentUser } from '../common/decorators/user.decorator';
-import { User, UserRole } from '../entities';
+import { User, UserMapRole, UserRole } from '../entities';
+import { InviteLinkService } from '../invite-link/invite-link.service';
 import { CreateMapDto } from './dtos/create-map.dto';
+import { InviteLinkResponseDto } from './dtos/invite-link-response.dto';
 import { MapItemForUserDto } from './dtos/map-item-for-user.dto';
 import { MapResponseDto } from './dtos/map-response.dto';
 import { UpdateMapDto } from './dtos/update-map.dto';
@@ -27,12 +31,16 @@ import { MapService } from './map.service';
 @ApiTags('maps')
 @Controller('maps')
 export class MapController {
-  constructor(private readonly mapService: MapService) {}
+  constructor(
+    private readonly mapService: MapService,
+    private readonly inviteLinkService: InviteLinkService,
+  ) {}
 
   @Post()
   @UseAuthGuard([UserRole.USER])
   @ApiOkResponse({ type: MapItemForUserDto })
   @ApiOperation({ summary: '새 지도를 생성합니다' })
+  @ApiBearerAuth()
   create(@Body() createMapDto: CreateMapDto, @CurrentUser() user: User) {
     // ensure alpha numeric
     if (!/[A-Za-z0-9-_]/.test(createMapDto.id)) {
@@ -55,8 +63,9 @@ export class MapController {
   @Get(':id')
   @ApiOkResponse({ type: MapResponseDto })
   @ApiBearerAuth()
+  @UseMapRoleGuard()
+  @UseAuthGuard([UserRole.USER])
   findOne(@Param('id') id: string) {
-    // TODO: findOne For user로 만들어서 (ADMIN, READ, WRITE)권한없으면 403을 반환하는 라우트를 만들어야 합니다.
     return this.mapService.findOne({ id });
   }
 
@@ -72,5 +81,17 @@ export class MapController {
   @ApiBearerAuth()
   remove(@Param('id') id: string) {
     return this.mapService.remove(id);
+  }
+
+  @Post(':id/invite-link')
+  @ApiResponse({ type: InviteLinkResponseDto })
+  @UseMapRoleGuard([UserMapRole.ADMIN])
+  @UseAuthGuard([UserRole.USER])
+  @ApiBearerAuth()
+  async createInviteLink(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+  ): Promise<InviteLinkResponseDto> {
+    return this.inviteLinkService.create(id, user);
   }
 }

--- a/src/map/map.controller.ts
+++ b/src/map/map.controller.ts
@@ -37,10 +37,10 @@ export class MapController {
   ) {}
 
   @Post()
-  @UseAuthGuard([UserRole.USER])
   @ApiOkResponse({ type: MapItemForUserDto })
   @ApiOperation({ summary: '새 지도를 생성합니다' })
   @ApiBearerAuth()
+  @UseAuthGuard([UserRole.USER])
   create(@Body() createMapDto: CreateMapDto, @CurrentUser() user: User) {
     // ensure alpha numeric
     if (!/[A-Za-z0-9-_]/.test(createMapDto.id)) {
@@ -53,9 +53,10 @@ export class MapController {
   }
 
   @Get()
-  @UseAuthGuard([UserRole.USER])
   @ApiOperation({ summary: '사용자가 속해있는 지도를 가져옵니다' })
   @ApiOkResponse({ type: [MapItemForUserDto] })
+  @ApiBearerAuth()
+  @UseAuthGuard([UserRole.USER])
   findAll(@CurrentUser() user: User) {
     return this.mapService.findAll(user);
   }
@@ -72,22 +73,27 @@ export class MapController {
   @Patch(':id')
   @ApiOkResponse({ type: MapResponseDto })
   @ApiBearerAuth()
+  @UseMapRoleGuard([UserMapRole.ADMIN])
+  @UseAuthGuard([UserRole.USER])
   update(@Param('id') id: string, @Body() updateMapDto: UpdateMapDto) {
     return this.mapService.update(id, updateMapDto);
   }
 
-  @Delete(':id')
-  @ApiOkResponse({ type: Number })
-  @ApiBearerAuth()
-  remove(@Param('id') id: string) {
-    return this.mapService.remove(id);
-  }
+  // TODO
+  // @Delete(':id')
+  // @ApiOkResponse({ type: Number })
+  // @ApiBearerAuth()
+  // @UseMapRoleGuard([UserMapRole.ADMIN])
+  // @UseAuthGuard([UserRole.USER])
+  // remove(@Param('id') id: string) {
+  //   return this.mapService.remove(id);
+  // }
 
   @Post(':id/invite-link')
   @ApiResponse({ type: InviteLinkResponseDto })
+  @ApiBearerAuth()
   @UseMapRoleGuard([UserMapRole.ADMIN])
   @UseAuthGuard([UserRole.USER])
-  @ApiBearerAuth()
   async createInviteLink(
     @CurrentUser() user: User,
     @Param('id') id: string,

--- a/src/map/map.module.ts
+++ b/src/map/map.module.ts
@@ -2,15 +2,22 @@ import { Module } from '@nestjs/common';
 
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 
-import { GroupMap, UserMap } from 'src/entities';
+import { InviteLinkModule } from 'src/invite-link/invite-link.module';
 
+import { GroupMap, UserMap } from '../entities';
+import { UserMapService } from '../user-map/user-map.service';
+import { UserModule } from '../user/user.module';
 import { MapController } from './map.controller';
 import { MapService } from './map.service';
 
 @Module({
-  imports: [MikroOrmModule.forFeature([GroupMap, UserMap])],
+  imports: [
+    MikroOrmModule.forFeature([GroupMap, UserMap]),
+    UserModule,
+    InviteLinkModule,
+  ],
   controllers: [MapController],
-  providers: [MapService],
+  providers: [MapService, UserMapService],
   exports: [MapService],
 })
 export class MapModule {}

--- a/src/map/map.service.ts
+++ b/src/map/map.service.ts
@@ -114,13 +114,19 @@ export class MapService {
   }
 
   async update(id: string, updateMapDto: UpdateMapDto) {
-    const map = await this.mapRepository.findOneOrFail(id);
-    // TODO: 이거 다시 구현
+    const map = await this.mapRepository.findOne(id);
+    if (!map) {
+      throw new NotFoundException(`존재하지 않는 지도입니다.`);
+    }
+
+    Object.assign(map, updateMapDto);
+
     await this.mapRepository.persistAndFlush(map);
     return map;
   }
 
-  remove(id: string) {
-    return this.mapRepository.nativeDelete({ id });
-  }
+  // TODO : hard delete vs soft delete
+  // remove(id: string) {
+  //   return this.mapRepository.nativeDelete({ id });
+  // }
 }

--- a/src/migrations/Migration20240704075203.ts
+++ b/src/migrations/Migration20240704075203.ts
@@ -1,0 +1,17 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20240704075203 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'create table "invite_link" ("token" varchar(255) not null, "created_by_id" int not null, "map_id" varchar(255) not null, "expires_at" timestamptz not null, "created_at" timestamptz not null, "updated_at" timestamptz not null, constraint "invite_link_pkey" primary key ("token"));',
+    );
+
+    this.addSql(
+      'alter table "invite_link" add constraint "invite_link_created_by_id_foreign" foreign key ("created_by_id") references "user" ("id") on update cascade;',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql('drop table if exists "invite_link" cascade;');
+  }
+}

--- a/src/migrations/Migration20240704161121.ts
+++ b/src/migrations/Migration20240704161121.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20240704161121 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'alter table "invite_link" add column "map_role" varchar(255) not null default \'WRITE\';',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "invite_link" drop column "map_role";');
+  }
+}

--- a/src/user-map/user-map.service.spec.ts
+++ b/src/user-map/user-map.service.spec.ts
@@ -7,7 +7,13 @@ import {
   MockRepository,
   MockRepositoryFactory,
 } from 'src/common/helper/mock.helper';
-import { UserMap, UserMapRepository } from 'src/entities';
+import {
+  GroupMap,
+  User,
+  UserMap,
+  UserMapRepository,
+  UserMapRole,
+} from 'src/entities';
 
 import { UserMapService } from './user-map.service';
 
@@ -40,5 +46,24 @@ describe('UserMapService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined();
     expect(mockedRepository).toBeDefined();
+  });
+
+  it('should get the user-map by user_id, map_id', async () => {
+    const userId = 1;
+    const mapId = 'test-map';
+
+    const existUserMap = new UserMap();
+    existUserMap.user = new User();
+    existUserMap.user.id = userId;
+    existUserMap.map = new GroupMap();
+    existUserMap.map.id = mapId;
+    existUserMap.role = UserMapRole.ADMIN;
+
+    jest.spyOn(mockedRepository, 'findOne').mockResolvedValue(existUserMap);
+
+    const userMap = await service.findOneByUserAndMap(userId, mapId);
+
+    expect(userMap).toBeDefined();
+    expect(userMap).toEqual(existUserMap);
   });
 });

--- a/src/user-map/user-map.service.ts
+++ b/src/user-map/user-map.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 
+import { FilterQuery } from '@mikro-orm/core';
 import { InjectRepository } from '@mikro-orm/nestjs';
 
 import { UserMap, UserMapRepository } from 'src/entities';
@@ -19,10 +20,23 @@ export class UserMapService {
   // findAll(): Promise<UserMap[]> {
   //   return this.userMapRepository.findAll();
   // }
-
+  //
   // findOne(where: FilterQuery<UserMap>): Promise<UserMap> {
   //   return this.userMapRepository.findOne(where);
   // }
+
+  async findOneByUserAndMap(userId: number, mapId: string): Promise<UserMap> {
+    const where: FilterQuery<UserMap> = {
+      user: { id: userId },
+      map: { id: mapId },
+    };
+
+    const userMap = await this.userMapRepository.findOne(where);
+    if (!userMap) {
+      throw new NotFoundException('해당 유저는 해당 지도의 멤버가 아닙니다.');
+    }
+    return userMap;
+  }
   // async update(id: string, updateUserMapDto: UpdateUserMapDto) {
   //   const userMap = await this.userMapRepository.findOneOrFail(id);
   //   wrap(userMap).assign(updateUserMapDto);

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -53,7 +53,6 @@ export class UserService {
   async checkDuplicateNickname(nickname: string) {
     const user = await this.userRepository.findOne({ nickname });
     if (user != undefined) {
-      console.log('afdfs');
       throw new DuplicateNicknameException();
     }
   }

--- a/src/util/util.service.ts
+++ b/src/util/util.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
+import * as crypto from 'node:crypto';
+
 @Injectable()
 export class UtilService {
   constructor(private readonly configService: ConfigService) {}
@@ -27,5 +29,13 @@ export class UtilService {
         {} as Record<string, T>,
       ),
     );
+  }
+
+  generateMD5TokenWithSalt(input: string, saltSize: number): string {
+    const saltBytes = crypto.randomBytes(saltSize);
+    return crypto
+      .createHash('md5')
+      .update(input + saltBytes)
+      .digest('hex');
   }
 }


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Refactoring (no functional changes, no api changes)

## For what purpose

- Create map invite-link API 구현
- Update map API 수정

## Key changes

1. Create map invite-link API 구현
    - invite-link module, service 생성 
    - map controller에서 invite-link service 호출
    - 유효기간 7일로 설정해둠
2. user-map 권한체크를 위한 guard 추가
3. 지도 생성/수정/조회 API 수정
    - swagger authorization header 설정 추가
    - userMap 권한체크를 위한 guard 적용

## To reviewers

- 지도 삭제 API는 mvp 범위가 아니기도 하고, hard delete vs soft delete 고민도 필요해서 추후 구현으로 미뤘습니다.(주석처리)
- invite-link 에 `map-role` 컬럼을 두어 해당 링크로 지도에 가입할 때, `map-role`을 갖는 것으로 처리 하고 싶었습니다.
    - `map-role` 기본값 = `WRITE`
- 초대링크의 도메인이 프론트 도메인이라, 백엔드에서는 링크의 토큰 부분만 response 하도록 작성했습니다. 
- invite-link controller는 따로 없는게 맞겠죠? 

## Screenshots
