### PR TITLE
Feat: 장소 조회 API 수정

### DIFF
--- a/src/place/dto/place-for-map-response.dto.ts
+++ b/src/place/dto/place-for-map-response.dto.ts
@@ -23,6 +23,9 @@ export class MenuItem {
 
   @ApiProperty()
   price: string;
+
+  @ApiProperty()
+  photo: string;
 }
 
 export class OpenTime {
@@ -48,13 +51,11 @@ export class OffDay {
 }
 
 export class KakaoPlaceResponseDto implements Partial<KakaoPlace> {
-  @ApiProperty({
-    description: '카카오맵에서 제공하는 장소의 ID (basicInfo.cid)',
-  })
+  @ApiProperty()
   @IsNotEmpty()
   id: number;
 
-  @ApiProperty({ description: '카카오맵 basicInfo.placenamefull' })
+  @ApiProperty()
   name: string;
 
   @ApiProperty()
@@ -75,27 +76,122 @@ export class KakaoPlaceResponseDto implements Partial<KakaoPlace> {
   })
   menuList: MenuItem[];
 
+  @ApiProperty()
+  mainPhotoUrl: string;
+
   @ApiProperty({ type: String, isArray: true })
   photoList: string[];
+
+  @ApiProperty()
+  score: number;
+
+  @ApiProperty()
+  commentCnt: number;
+
+  @ApiProperty()
+  blogReviewCnt: number;
+
+  @ApiProperty({ type: OpenTime, isArray: true })
+  openTimeList: OpenTime[];
+
+  @ApiProperty({ type: OffDay, isArray: true })
+  offDayList: OffDay[];
 }
 
-export class PlaceResponseDto implements Partial<Place> {
+export class PlaceResponseDto implements Omit<KakaoPlaceResponseDto, 'id'> {
   @ApiProperty()
   id: number;
 
-  @ApiProperty({ type: KakaoPlaceResponseDto })
-  kakaoPlace: KakaoPlace;
+  @ApiProperty()
+  mapId: string;
+
+  @ApiProperty({ type: Number, isArray: true })
+  likedUserIds: number[];
+
+  @ApiProperty({ type: TagResponseDto, isArray: true })
+  tags: TagResponseDto[];
+
+  @ApiProperty({ type: CreatedUser })
+  createdBy: CreatedUser;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  category: string;
+
+  @ApiProperty()
+  address: string;
 
   @ApiProperty()
   x: number;
 
   @ApiProperty()
   y: number;
+
+  @ApiProperty({
+    type: MenuItem,
+    isArray: true,
+  })
+  menuList: MenuItem[];
+
+  @ApiProperty()
+  mainPhotoUrl: string;
+
+  @ApiProperty({ type: String, isArray: true })
+  photoList: string[];
+
+  @ApiProperty()
+  score: number;
+
+  @ApiProperty()
+  commentCnt: number;
+
+  @ApiProperty()
+  blogReviewCnt: number;
+
+  @ApiProperty({ type: OpenTime, isArray: true })
+  openTimeList: OpenTime[];
+
+  @ApiProperty({ type: OffDay, isArray: true })
+  offDayList: OffDay[];
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
+
+  constructor(placeForMap: PlaceForMap) {
+    const { place } = placeForMap;
+    const { kakaoPlace } = place;
+
+    this.id = place.id;
+    this.mapId = placeForMap.map.id;
+    this.likedUserIds = placeForMap.likedUserIds;
+    this.tags = placeForMap.tags.map((tag) => new TagResponseDto(tag));
+    this.createdBy = new CreatedUser(placeForMap.createdBy);
+    this.name = kakaoPlace.name;
+    this.category = kakaoPlace.category;
+    this.address = kakaoPlace.address;
+    this.x = kakaoPlace.x;
+    this.y = kakaoPlace.y;
+    this.menuList = kakaoPlace.menuList;
+    this.mainPhotoUrl = kakaoPlace.mainPhotoUrl;
+    this.photoList = kakaoPlace.photoList;
+    this.score = kakaoPlace.score;
+    this.commentCnt = kakaoPlace.commentCnt;
+    this.blogReviewCnt = kakaoPlace.blogReviewCnt;
+    this.openTimeList = kakaoPlace.openTimeList;
+    this.offDayList = kakaoPlace.offDayList;
+    this.createdAt = placeForMap.createdAt;
+    this.updatedAt = placeForMap.updatedAt;
+  }
 }
 
 export class PlaceForMapResponseDto {
-  @ApiProperty({ type: PlaceResponseDto })
-  place: PlaceResponseDto;
+  @ApiProperty({ type: Place })
+  place: Place;
 
   @ApiProperty({ type: TagResponseDto, isArray: true })
   tags: TagResponseDto[];

--- a/src/place/place.controller.ts
+++ b/src/place/place.controller.ts
@@ -74,14 +74,9 @@ export class PlaceController {
   @Delete(':mapId/:placeId')
   async deletePlaceByKakaoId(
     @Param('mapId') mapId: string,
-    @Param('placeId') placeId: number,
-    @CurrentUser() user: User,
+    @Param('placeId') placeId: string,
   ) {
-    await this.placeService.remove({
-      mapId,
-      placeId,
-      user,
-    });
+    await this.placeService.remove(mapId, +placeId);
   }
 
   @ApiOperation({ summary: '맛집 좋아요' })

--- a/src/place/place.controller.ts
+++ b/src/place/place.controller.ts
@@ -8,7 +8,10 @@ import {
 } from '@nestjs/swagger';
 
 import { RegisterPlaceDto } from 'src/place/dto/create-tag.dto';
-import { PlaceForMapResponseDto } from 'src/place/dto/place-for-map-response.dto';
+import {
+  PlaceForMapResponseDto,
+  PlaceResponseDto,
+} from 'src/place/dto/place-for-map-response.dto';
 
 import { UseAuthGuard } from '../common/decorators/auth-guard.decorator';
 import { CurrentUser } from '../common/decorators/user.decorator';
@@ -34,7 +37,6 @@ export class PlaceController {
   @ApiOperation({ summary: '카카오 place id로 장소 등록' })
   @ApiParam({ name: 'mapId', description: '지도(GroupMap) id' })
   @ApiParam({ name: 'kakaoPlaceId', description: '카카오 place id' })
-  @ApiResponse({ type: PlaceForMapResponseDto })
   @UseAuthGuard([UserRole.USER])
   @Put(':mapId/kakao/:kakaoPlaceId')
   async registerPlaceByKakaoId(
@@ -54,7 +56,7 @@ export class PlaceController {
   @ApiOperation({ summary: '저장된 place id로 장소 조회' })
   @ApiParam({ name: 'mapId', description: '지도(GroupMap) id' })
   @ApiParam({ name: 'placeId', description: '등록된 place id' })
-  @ApiResponse({ type: PlaceForMapResponseDto })
+  @ApiResponse({ type: PlaceResponseDto })
   @UseAuthGuard([UserRole.USER])
   @Get(':mapId/:placeId')
   async getPlaceInMap(

--- a/src/place/place.controller.ts
+++ b/src/place/place.controller.ts
@@ -57,7 +57,7 @@ export class PlaceController {
   @ApiResponse({ type: PlaceForMapResponseDto })
   @UseAuthGuard([UserRole.USER])
   @Get(':mapId/:placeId')
-  async getPlaceByKakaoId(
+  async getPlaceInMap(
     @Param('mapId') mapId: string,
     @Param('placeId') placeId: number,
   ) {

--- a/src/place/place.controller.ts
+++ b/src/place/place.controller.ts
@@ -7,6 +7,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
+import { UseMapRoleGuard } from 'src/common/decorators/map-role-guard.decorator';
 import { RegisterPlaceDto } from 'src/place/dto/create-tag.dto';
 import {
   PlaceForMapResponseDto,
@@ -15,7 +16,7 @@ import {
 
 import { UseAuthGuard } from '../common/decorators/auth-guard.decorator';
 import { CurrentUser } from '../common/decorators/user.decorator';
-import { User, UserRole } from '../entities';
+import { User, UserMapRole, UserRole } from '../entities';
 import { PlaceService } from './place.service';
 
 @ApiTags('place')
@@ -73,6 +74,7 @@ export class PlaceController {
   @ApiParam({ name: 'mapId', description: '지도(GroupMap) id' })
   @ApiParam({ name: 'placeId', description: 'place id' })
   @UseAuthGuard([UserRole.USER])
+  @UseMapRoleGuard([UserMapRole.ADMIN, UserMapRole.WRITE])
   @Delete(':mapId/:placeId')
   async deletePlaceByKakaoId(
     @Param('mapId') mapId: string,

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -5,7 +5,10 @@ import { InjectRepository } from '@mikro-orm/nestjs';
 
 import { PlaceNotFoundException } from 'src/exceptions';
 import { RegisterPlaceDto } from 'src/place/dto/create-tag.dto';
-import { PlaceForMapResponseDto } from 'src/place/dto/place-for-map-response.dto';
+import {
+  PlaceForMapResponseDto,
+  PlaceResponseDto,
+} from 'src/place/dto/place-for-map-response.dto';
 
 import {
   GroupMap,
@@ -101,7 +104,13 @@ export class PlaceService {
     return { placeId: place.id };
   }
 
-  async findOne({ mapId, placeId }: { mapId: string; placeId: number }) {
+  async findOne({
+    mapId,
+    placeId,
+  }: {
+    mapId: string;
+    placeId: number;
+  }): Promise<PlaceResponseDto> {
     const place = await this.placeForMapRepository.findOne(
       {
         map: rel(GroupMap, mapId),
@@ -113,7 +122,7 @@ export class PlaceService {
       throw new PlaceNotFoundException();
     }
 
-    return place;
+    return new PlaceResponseDto(place);
   }
 
   async likePlace({
@@ -126,7 +135,7 @@ export class PlaceService {
     placeId: number;
     user: User;
     like: boolean;
-  }): Promise<PlaceForMapResponseDto> {
+  }) {
     const placeForMap = await this.placeForMapRepository.findOneOrFail(
       {
         place: rel(Place, placeId),
@@ -146,7 +155,6 @@ export class PlaceService {
     }
 
     await this.placeForMapRepository.persistAndFlush(placeForMap);
-    return new PlaceForMapResponseDto(placeForMap);
   }
 
   async remove(mapId: string, placeId: number): Promise<void> {

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -149,14 +149,7 @@ export class PlaceService {
     return new PlaceForMapResponseDto(placeForMap);
   }
 
-  async remove({
-    mapId,
-    placeId,
-  }: {
-    mapId: string;
-    placeId: number;
-    user: User;
-  }): Promise<void> {
+  async remove(mapId: string, placeId: number): Promise<void> {
     const placeForMap = await this.placeForMapRepository.findOne({
       place: rel(Place, placeId),
       map: rel(GroupMap, mapId),

--- a/src/search/dtos/searched-place-response.dto.ts
+++ b/src/search/dtos/searched-place-response.dto.ts
@@ -11,10 +11,7 @@ export class SearchedPlaceResponseDto {
   kakaoId: number;
 
   @ApiProperty()
-  categoryGroupName: string;
-
-  @ApiProperty()
-  categoryName: string;
+  category: string;
 
   @ApiProperty()
   x: number;
@@ -26,10 +23,7 @@ export class SearchedPlaceResponseDto {
   placeName: string;
 
   @ApiProperty()
-  addressName: string;
-
-  @ApiProperty()
-  roadAddressName: string;
+  address: string;
 
   @ApiProperty()
   placeId: number;
@@ -56,11 +50,11 @@ export class SearchedPlaceResponseDto {
       const { kakaoPlace } = place;
 
       this.kakaoId = kakaoPlace.id;
-      this.categoryName = kakaoPlace.category;
+      this.category = kakaoPlace.category;
       this.x = kakaoPlace.x;
       this.y = kakaoPlace.y;
       this.placeName = kakaoPlace.name;
-      this.addressName = kakaoPlace.address;
+      this.address = kakaoPlace.address;
       this.placeId = place.id;
       this.tags = searchedPlace.tags.map((tag) => `#${tag.content}`);
       this.createdBy = new CreatedUser(searchedPlace.createdBy);
@@ -68,13 +62,11 @@ export class SearchedPlaceResponseDto {
       this.likedUserCount = searchedPlace.likedUserIds.length;
     } else {
       this.kakaoId = Number(searchedPlace.id);
-      this.categoryGroupName = searchedPlace.category_group_name;
-      this.categoryName = searchedPlace.category_name;
+      this.category = searchedPlace.category_name;
       this.x = Number(searchedPlace.x);
       this.y = Number(searchedPlace.y);
       this.placeName = searchedPlace.place_name;
-      this.addressName = searchedPlace.address_name;
-      this.roadAddressName = searchedPlace.road_address_name;
+      this.address = searchedPlace.road_address_name;
     }
   }
 }

--- a/src/search/dtos/searched-place-response.dto.ts
+++ b/src/search/dtos/searched-place-response.dto.ts
@@ -8,6 +8,9 @@ import { KakaoPlaceItem } from 'src/search/kakao-map.types';
 
 export class SearchedPlaceResponseDto {
   @ApiProperty()
+  isRegisteredPlace: boolean;
+
+  @ApiProperty()
   kakaoId: number;
 
   @ApiProperty()
@@ -33,8 +36,8 @@ export class SearchedPlaceResponseDto {
   tags?: string[];
 
   @ApiProperty({ type: CreatedUser })
-  @ApiProperty()
-  createdBy: CreatedUser;
+  @IsOptional()
+  createdBy?: CreatedUser;
 
   @ApiProperty()
   @IsOptional()
@@ -42,13 +45,14 @@ export class SearchedPlaceResponseDto {
 
   @ApiProperty()
   @IsOptional()
-  likedUserCount?: number;
+  likedUserIds?: number[];
 
   constructor(searchedPlace: KakaoPlaceItem | PlaceForMap) {
     if ('place' in searchedPlace) {
       const { place } = searchedPlace;
       const { kakaoPlace } = place;
 
+      this.isRegisteredPlace = true;
       this.kakaoId = kakaoPlace.id;
       this.category = kakaoPlace.category;
       this.x = kakaoPlace.x;
@@ -59,10 +63,11 @@ export class SearchedPlaceResponseDto {
       this.tags = searchedPlace.tags.map((tag) => `#${tag.content}`);
       this.createdBy = new CreatedUser(searchedPlace.createdBy);
       this.score = kakaoPlace.score;
-      this.likedUserCount = searchedPlace.likedUserIds.length;
+      this.likedUserIds = searchedPlace.likedUserIds;
     } else {
+      this.isRegisteredPlace = false;
       this.kakaoId = Number(searchedPlace.id);
-      this.category = searchedPlace.category_name;
+      this.category = searchedPlace.category_group_name;
       this.x = Number(searchedPlace.x);
       this.y = Number(searchedPlace.y);
       this.placeName = searchedPlace.place_name;

--- a/src/search/dtos/searched-place-response.dto.ts
+++ b/src/search/dtos/searched-place-response.dto.ts
@@ -1,0 +1,80 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsOptional } from 'class-validator';
+
+import { PlaceForMap } from 'src/entities';
+import { CreatedUser } from 'src/place/dto/place-for-map-response.dto';
+import { KakaoPlaceItem } from 'src/search/kakao-map.types';
+
+export class SearchedPlaceResponseDto {
+  @ApiProperty()
+  kakaoId: number;
+
+  @ApiProperty()
+  categoryGroupName: string;
+
+  @ApiProperty()
+  categoryName: string;
+
+  @ApiProperty()
+  x: number;
+
+  @ApiProperty()
+  y: number;
+
+  @ApiProperty()
+  placeName: string;
+
+  @ApiProperty()
+  addressName: string;
+
+  @ApiProperty()
+  roadAddressName: string;
+
+  @ApiProperty()
+  placeId: number;
+
+  @ApiProperty()
+  @IsOptional()
+  tags?: string[];
+
+  @ApiProperty({ type: CreatedUser })
+  @ApiProperty()
+  createdBy: CreatedUser;
+
+  @ApiProperty()
+  @IsOptional()
+  score?: number;
+
+  @ApiProperty()
+  @IsOptional()
+  likedUserCount?: number;
+
+  constructor(searchedPlace: KakaoPlaceItem | PlaceForMap) {
+    if ('place' in searchedPlace) {
+      const { place } = searchedPlace;
+      const { kakaoPlace } = place;
+
+      this.kakaoId = kakaoPlace.id;
+      this.categoryName = kakaoPlace.category;
+      this.x = kakaoPlace.x;
+      this.y = kakaoPlace.y;
+      this.placeName = kakaoPlace.name;
+      this.addressName = kakaoPlace.address;
+      this.placeId = place.id;
+      this.tags = searchedPlace.tags.map((tag) => `#${tag.content}`);
+      this.createdBy = new CreatedUser(searchedPlace.createdBy);
+      this.score = kakaoPlace.score;
+      this.likedUserCount = searchedPlace.likedUserIds.length;
+    } else {
+      this.kakaoId = Number(searchedPlace.id);
+      this.categoryGroupName = searchedPlace.category_group_name;
+      this.categoryName = searchedPlace.category_name;
+      this.x = Number(searchedPlace.x);
+      this.y = Number(searchedPlace.y);
+      this.placeName = searchedPlace.place_name;
+      this.addressName = searchedPlace.address_name;
+      this.roadAddressName = searchedPlace.road_address_name;
+    }
+  }
+}

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -46,7 +46,7 @@ export class SearchController {
   })
   @ApiOperation({ summary: '위도 경도 좌표계 쿼리' })
   @ApiResponse({ type: SearchedPlaceResponseDto, isArray: true })
-  @Get('places')
+  @Get('places/kakao')
   async searchPlacesByCoord(
     @Query('q') q: string,
     @Query('rect') rect: string,
@@ -59,6 +59,11 @@ export class SearchController {
     type: String,
     name: 'rect',
     description: '경도위도 "x1,y1,x2,y2"',
+  })
+  @ApiQuery({
+    type: String,
+    name: 'mapId',
+    description: '해당 map id',
   })
   @ApiOperation({
     summary:

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -71,7 +71,7 @@ export class SearchController {
   })
   @ApiResponse({ type: SearchedPlaceResponseDto, isArray: true })
   @Get('places')
-  async test(
+  async searchPlacesWithMap(
     @Query('q') q: string,
     @Query('rect') rect: string,
     @Query('mapId') mapId: string,

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Param, Query } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiExcludeEndpoint,
   ApiOperation,
   ApiQuery,
   ApiResponse,
@@ -11,6 +12,7 @@ import { UseAuthGuard } from 'src/common/decorators/auth-guard.decorator';
 import { CurrentUser } from 'src/common/decorators/user.decorator';
 import { User, UserRole } from 'src/entities';
 import { PlaceResponseDto } from 'src/place/dto/place-for-map-response.dto';
+import { SearchedPlaceResponseDto } from 'src/search/dtos/searched-place-response.dto';
 import { UserService } from 'src/user/user.service';
 
 import { SearchService } from './search.service';
@@ -35,7 +37,7 @@ export class SearchController {
     return await this.searchService.suggest(q);
   }
 
-  // 위도 경도 좌표계 쿼리
+  @ApiExcludeEndpoint()
   @ApiQuery({ type: String, name: 'q', description: '검색을 원하는 질의어' })
   @ApiQuery({
     type: String,
@@ -43,12 +45,33 @@ export class SearchController {
     description: '경도위도 "x1,y1,x2,y2"',
   })
   @ApiOperation({ summary: '위도 경도 좌표계 쿼리' })
+  @ApiResponse({ type: SearchedPlaceResponseDto, isArray: true })
   @Get('places')
   async searchPlacesByCoord(
     @Query('q') q: string,
     @Query('rect') rect: string,
   ) {
     return await this.searchService.searchPlaceList(q, rect);
+  }
+
+  @ApiQuery({ type: String, name: 'q', description: '검색을 원하는 질의어' })
+  @ApiQuery({
+    type: String,
+    name: 'rect',
+    description: '경도위도 "x1,y1,x2,y2"',
+  })
+  @ApiOperation({
+    summary:
+      '위도 경도 좌표계 쿼리, 맵에 등록된 place가 있으면 화면에 표시될 정보도 같이 전달됩니다.',
+  })
+  @ApiResponse({ type: SearchedPlaceResponseDto, isArray: true })
+  @Get('places')
+  async test(
+    @Query('q') q: string,
+    @Query('rect') rect: string,
+    @Query('mapId') mapId: string,
+  ) {
+    return await this.searchService.searchPlacesWithMap(q, rect, mapId);
   }
 
   // 카카오 좌표계(wcongnamul) 쿼리

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -11,7 +11,7 @@ import {
 import { UseAuthGuard } from 'src/common/decorators/auth-guard.decorator';
 import { CurrentUser } from 'src/common/decorators/user.decorator';
 import { User, UserRole } from 'src/entities';
-import { PlaceResponseDto } from 'src/place/dto/place-for-map-response.dto';
+import { KakaoPlaceResponseDto } from 'src/place/dto/place-for-map-response.dto';
 import { SearchedPlaceResponseDto } from 'src/search/dtos/searched-place-response.dto';
 import { UserService } from 'src/user/user.service';
 
@@ -104,7 +104,7 @@ export class SearchController {
     required: false,
     description: '장소디테일 캐시를 무효화 할지 여부 (default false)',
   })
-  @ApiResponse({ type: PlaceResponseDto })
+  @ApiResponse({ type: KakaoPlaceResponseDto })
   @Get('places/kakao/:id')
   async searchPlaceDetail(
     @Param('id') id: string,

--- a/src/search/search.module.ts
+++ b/src/search/search.module.ts
@@ -6,7 +6,7 @@ import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { UserModule } from 'src/user/user.module';
 import { UtilModule } from 'src/util/util.module';
 
-import { KakaoPlace } from '../entities';
+import { KakaoPlace, PlaceForMap } from '../entities';
 import { KakaoMapHelper } from './kakao-map.helper';
 import { SearchController } from './search.controller';
 import { SearchService } from './search.service';
@@ -15,7 +15,7 @@ import { SearchService } from './search.service';
   imports: [
     HttpModule,
     UtilModule,
-    MikroOrmModule.forFeature([KakaoPlace]),
+    MikroOrmModule.forFeature([KakaoPlace, PlaceForMap]),
     UserModule,
   ],
   controllers: [SearchController],

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -143,10 +143,10 @@ export class SearchService {
       kakaoPlace = new KakaoPlace();
       const basicInfo = kakaoPlaceRaw.basicInfo;
       const feedback = basicInfo.feedback;
-
+      console.log(basicInfo);
       kakaoPlace.id = basicInfo.cid;
       kakaoPlace.name = basicInfo.placenamefull;
-      kakaoPlace.address = basicInfo.placenamefull;
+      kakaoPlace.address = basicInfo.address.newaddr.newaddrfull;
       kakaoPlace.category = basicInfo.category.cate1name;
       kakaoPlace.blogReviewCnt = feedback.blogrvwcnt;
       kakaoPlace.commentCnt = feedback.comntcnt;

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -2,11 +2,19 @@ import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
+import { rel } from '@mikro-orm/core';
 import { InjectRepository } from '@mikro-orm/nestjs';
 
+import { SearchedPlaceResponseDto } from 'src/search/dtos/searched-place-response.dto';
 import { UtilService } from 'src/util/util.service';
 
-import { KakaoPlace, KakaoPlaceRepository } from '../entities';
+import {
+  GroupMap,
+  KakaoPlace,
+  KakaoPlaceRepository,
+  PlaceForMap,
+  PlaceForMapRepository,
+} from '../entities';
 import { KAKAO_SCRAPING_HEADERS, KakaoMapHelper } from './kakao-map.helper';
 import {
   KakaoCategoryGroupCode,
@@ -24,6 +32,8 @@ export class SearchService {
     private readonly utilService: UtilService,
     @InjectRepository(KakaoPlace)
     private readonly kakaoPlaceRepository: KakaoPlaceRepository,
+    @InjectRepository(PlaceForMap)
+    private readonly placeForMapRepository: PlaceForMapRepository,
     private readonly configService: ConfigService,
   ) {}
 
@@ -44,7 +54,7 @@ export class SearchService {
     query: string,
     rect: string,
     { isKakaoCoord = false }: { isKakaoCoord?: boolean } = {},
-  ): Promise<KakaoPlaceItem[]> {
+  ): Promise<SearchedPlaceResponseDto[]> {
     if (isKakaoCoord) {
       rect = await this.kakaoMapHelper.congNamulRectToLongLatRect(rect);
     }
@@ -53,7 +63,63 @@ export class SearchService {
       this.searchPlace(query, rect, KakaoCategoryGroupCode['카페']),
       this.searchPlace(query, rect, KakaoCategoryGroupCode['음식점']),
     ]);
-    return this.utilService.uniqueBy([...list1, ...list2], (item) => item.id);
+    const searchedPlaces = this.utilService.uniqueBy(
+      [...list1, ...list2],
+      (item) => item.id,
+    );
+
+    return searchedPlaces.map((searchedPlace) => {
+      return new SearchedPlaceResponseDto(searchedPlace);
+    });
+  }
+
+  async searchPlacesWithMap(
+    query: string,
+    rect: string,
+    mapId: string,
+    { isKakaoCoord = false }: { isKakaoCoord?: boolean } = {},
+  ): Promise<SearchedPlaceResponseDto[]> {
+    if (isKakaoCoord) {
+      rect = await this.kakaoMapHelper.congNamulRectToLongLatRect(rect);
+    }
+
+    const [{ documents: list1 }, { documents: list2 }] = await Promise.all([
+      this.searchPlace(query, rect, KakaoCategoryGroupCode['카페']),
+      this.searchPlace(query, rect, KakaoCategoryGroupCode['음식점']),
+    ]);
+    const kakaoPlaceItems = this.utilService.uniqueBy(
+      [...list1, ...list2],
+      (item) => item.id,
+    );
+    const kakaoPlaceIds = kakaoPlaceItems.map((item) => Number(item.id));
+
+    const existingPlacesMap = await this.getExistingPlacesMap(
+      mapId,
+      kakaoPlaceIds,
+    );
+    const mergedPlaces = kakaoPlaceItems.map(
+      (kakaoPlace) => existingPlacesMap[kakaoPlace.id] ?? kakaoPlace,
+    );
+
+    return mergedPlaces.map((place) => new SearchedPlaceResponseDto(place));
+  }
+
+  async getExistingPlacesMap(
+    mapId: string,
+    kakaoPlaceIds: number[],
+  ): Promise<{ [key: string]: PlaceForMap }> {
+    const existingPlaces = await this.placeForMapRepository.find(
+      {
+        map: rel(GroupMap, mapId),
+        place: { kakaoPlace: { $in: kakaoPlaceIds } },
+      },
+      { populate: ['place', 'place.kakaoPlace', 'createdBy', 'tags'] },
+    );
+
+    return existingPlaces.reduce((map, placeForMap) => {
+      map[placeForMap.place.kakaoPlace.id] = placeForMap;
+      return map;
+    }, {});
   }
 
   async searchPlaceDetail(

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -143,7 +143,6 @@ export class SearchService {
       kakaoPlace = new KakaoPlace();
       const basicInfo = kakaoPlaceRaw.basicInfo;
       const feedback = basicInfo.feedback;
-      console.log(basicInfo);
       kakaoPlace.id = basicInfo.cid;
       kakaoPlace.name = basicInfo.placenamefull;
       kakaoPlace.address = basicInfo.address.newaddr.newaddrfull;


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Refactoring (no functional changes, no api changes)

## For what purpose

아래 데이터처럼 지도에 등록된 장소는 ui에 보여줄 데이터 포함해서 줄려고 (2,3번째 place 정보가 등록된 place임)
```
{
  "message": "success",
  "data": [
    {
      "kakaoId": 755017754,
      "category": "음식점 > 카페 > 커피전문점 > 스타벅스",
      "x": 126.92314497871375,
      "y": 37.52139976893209,
      "placeName": "스타벅스 여의도TP타워점",
      "address": "서울 영등포구 의사당대로 96"
    },
    {
      "kakaoId": 1669104295,
      "category": "음식점",
      "x": 126.92558789808376,
      "y": 37.52191670680391,
      "placeName": "스타벅스 여의도교직원공제회점",
      "address": "여의나루로 50",
      "placeId": 13,
      "tags": [],
      "createdBy": {
        "nickname": "11111",
        "id": 1
      },
      "score": 5,
      "likedUserCount": 0
    },
    {
      "kakaoId": 1945023864,
      "category": "음식점",
      "x": 126.92586907682352,
      "y": 37.52127536975003,
      "placeName": "스타벅스 여의도화재보험점",
      "address": "국제금융로6길 38",
      "placeId": 14,
      "tags": [
        "#string"
      ],
      "createdBy": {
        "nickname": "11111",
        "id": 1
      },
      "score": 3.6,
      "likedUserCount": 0
    }
  ]
}
```


## Key changes

- 장소 조회 API 수정 
  - map에 저장된 place를 데이터 전달
  - 장소 조회 responseDto 추가
- 검색어 따라 장소 조회할 때, map에 저장한 place 정보도 같이 줘야해서 기존 장소 검색 API swagger hide

## To reviewers
함수, 변수명 그리고 내부 로직 훈수 및 지적 환영
 
## Screenshots
