### PR TITLE
Feat/Place: mapId와 kakaoId 에 따라서 장소 조회 API 추가

### DIFF
--- a/src/common/guards/map-role.guard.ts
+++ b/src/common/guards/map-role.guard.ts
@@ -21,7 +21,7 @@ export class MapRoleGuard implements CanActivate {
 
     const request = context.switchToHttp().getRequest();
     const user = request.user;
-    const mapId = request.params.id;
+    const mapId = request.params.id || request.params.mapId;
 
     const hasMapRole = async () => {
       try {

--- a/src/common/guards/map-role.guard.ts
+++ b/src/common/guards/map-role.guard.ts
@@ -21,7 +21,7 @@ export class MapRoleGuard implements CanActivate {
 
     const request = context.switchToHttp().getRequest();
     const user = request.user;
-    const mapId = request.params.id || request.params.mapId;
+    const mapId = request.params.mapId || request.params.id;
 
     const hasMapRole = async () => {
       try {

--- a/src/place/dto/place-for-map-response.dto.ts
+++ b/src/place/dto/place-for-map-response.dto.ts
@@ -53,7 +53,10 @@ export class OffDay {
 export class KakaoPlaceResponseDto implements Partial<KakaoPlace> {
   @ApiProperty()
   @IsNotEmpty()
-  id: number;
+  kakaoId: number;
+
+  @ApiProperty()
+  isRegisteredPlace: boolean;
 
   @ApiProperty()
   name: string;
@@ -96,14 +99,38 @@ export class KakaoPlaceResponseDto implements Partial<KakaoPlace> {
 
   @ApiProperty({ type: OffDay, isArray: true })
   offDayList: OffDay[];
+
+  constructor(kakaoPlace: KakaoPlace) {
+    this.kakaoId = kakaoPlace.id;
+    this.isRegisteredPlace = false;
+    this.name = kakaoPlace.name;
+    this.category = kakaoPlace.category;
+    this.address = kakaoPlace.address;
+    this.x = kakaoPlace.x;
+    this.y = kakaoPlace.y;
+    this.menuList = kakaoPlace.menuList;
+    this.mainPhotoUrl = kakaoPlace.mainPhotoUrl;
+    this.photoList = kakaoPlace.photoList;
+    this.score = kakaoPlace.score;
+    this.commentCnt = kakaoPlace.commentCnt;
+    this.blogReviewCnt = kakaoPlace.blogReviewCnt;
+    this.openTimeList = kakaoPlace.openTimeList;
+    this.offDayList = kakaoPlace.offDayList;
+  }
 }
 
-export class PlaceResponseDto implements Omit<KakaoPlaceResponseDto, 'id'> {
+export class PlaceResponseDto implements KakaoPlaceResponseDto {
   @ApiProperty()
   id: number;
 
   @ApiProperty()
+  kakaoId: number;
+
+  @ApiProperty()
   mapId: string;
+
+  @ApiProperty()
+  isRegisteredPlace: boolean;
 
   @ApiProperty({ type: Number, isArray: true })
   likedUserIds: number[];
@@ -167,7 +194,9 @@ export class PlaceResponseDto implements Omit<KakaoPlaceResponseDto, 'id'> {
     const { kakaoPlace } = place;
 
     this.id = place.id;
+    this.kakaoId = kakaoPlace.id;
     this.mapId = placeForMap.map.id;
+    this.isRegisteredPlace = true;
     this.likedUserIds = placeForMap.likedUserIds;
     this.tags = placeForMap.tags.map((tag) => new TagResponseDto(tag));
     this.createdBy = new CreatedUser(placeForMap.createdBy);

--- a/src/place/place.controller.ts
+++ b/src/place/place.controller.ts
@@ -95,8 +95,8 @@ export class PlaceController {
   @ApiOperation({ summary: '맛집 장소 삭제' })
   @ApiParam({ name: 'mapId', description: '지도(GroupMap) id' })
   @ApiParam({ name: 'placeId', description: 'place id' })
+  @UseMapRoleGuard([UserMapRole.ADMIN, UserMapRole.WRITE])
   @UseAuthGuard([UserRole.USER])
-  // @UseMapRoleGuard([UserMapRole.ADMIN, UserMapRole.WRITE])
   @Delete(':mapId/:placeId')
   async deletePlaceByKakaoId(
     @Param('mapId') mapId: string,

--- a/src/place/place.controller.ts
+++ b/src/place/place.controller.ts
@@ -5,11 +5,13 @@ import {
   ApiParam,
   ApiResponse,
   ApiTags,
+  getSchemaPath,
 } from '@nestjs/swagger';
 
 import { UseMapRoleGuard } from 'src/common/decorators/map-role-guard.decorator';
 import { RegisterPlaceDto } from 'src/place/dto/create-tag.dto';
 import {
+  KakaoPlaceResponseDto,
   PlaceForMapResponseDto,
   PlaceResponseDto,
 } from 'src/place/dto/place-for-map-response.dto';
@@ -54,6 +56,29 @@ export class PlaceController {
     });
   }
 
+  @ApiOperation({
+    summary:
+      'kakaoId를 통해 place 상세 조회(장소 등록 여부에 따라 kakaoPlace, Place 상세 정보 반환)',
+  })
+  @ApiParam({ name: 'mapId', description: '지도(GroupMap) id' })
+  @ApiParam({ name: 'kakaoPlaceId', description: '카카오 place id' })
+  @UseAuthGuard([UserRole.USER])
+  @ApiResponse({
+    schema: {
+      oneOf: [
+        { $ref: getSchemaPath(PlaceResponseDto) },
+        { $ref: getSchemaPath(KakaoPlaceResponseDto) },
+      ],
+    },
+  })
+  @Get(':mapId/kakao/:kakaoPlaceId')
+  async getPlaceByKakaoId(
+    @Param('mapId') mapId: string,
+    @Param('kakaoPlaceId') kakaoPlaceId: number,
+  ) {
+    return await this.placeService.getPlaceByKakaoId(mapId, kakaoPlaceId);
+  }
+
   @ApiOperation({ summary: '저장된 place id로 장소 조회' })
   @ApiParam({ name: 'mapId', description: '지도(GroupMap) id' })
   @ApiParam({ name: 'placeId', description: '등록된 place id' })
@@ -64,17 +89,14 @@ export class PlaceController {
     @Param('mapId') mapId: string,
     @Param('placeId') placeId: number,
   ) {
-    return await this.placeService.findOne({
-      mapId,
-      placeId,
-    });
+    return await this.placeService.getPlace(mapId, placeId);
   }
 
   @ApiOperation({ summary: '맛집 장소 삭제' })
   @ApiParam({ name: 'mapId', description: '지도(GroupMap) id' })
   @ApiParam({ name: 'placeId', description: 'place id' })
   @UseAuthGuard([UserRole.USER])
-  @UseMapRoleGuard([UserMapRole.ADMIN, UserMapRole.WRITE])
+  // @UseMapRoleGuard([UserMapRole.ADMIN, UserMapRole.WRITE])
   @Delete(':mapId/:placeId')
   async deletePlaceByKakaoId(
     @Param('mapId') mapId: string,

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -6,6 +6,7 @@ import { InjectRepository } from '@mikro-orm/nestjs';
 import { PlaceNotFoundException } from 'src/exceptions';
 import { RegisterPlaceDto } from 'src/place/dto/create-tag.dto';
 import {
+  KakaoPlaceResponseDto,
   PlaceForMapResponseDto,
   PlaceResponseDto,
 } from 'src/place/dto/place-for-map-response.dto';
@@ -113,13 +114,22 @@ export class PlaceService {
     return { placeId: place.id };
   }
 
-  async findOne({
-    mapId,
-    placeId,
-  }: {
-    mapId: string;
-    placeId: number;
-  }): Promise<PlaceResponseDto> {
+  async getPlaceByKakaoId(mapId: string, kakaoPlaceId: number) {
+    const placeForMap = await this.placeForMapRepository.findOne({
+      place: { kakaoPlace: rel(KakaoPlace, kakaoPlaceId) },
+      map: rel(GroupMap, mapId),
+    });
+    if (!placeForMap) {
+      const kakaoPlaceDetail = await this.searchService.searchPlaceDetail(
+        String(kakaoPlaceId),
+        false,
+      );
+      return new KakaoPlaceResponseDto(kakaoPlaceDetail);
+    }
+    return await this.getPlace(mapId, placeForMap.place.id);
+  }
+
+  async getPlace(mapId: string, placeId: number): Promise<PlaceResponseDto> {
     const place = await this.placeForMapRepository.findOne(
       {
         map: rel(GroupMap, mapId),


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Refactoring (no functional changes, no api changes)

## For what purpose
지도에 등록되어있지 않은 장소도 상세조회가 필요합니다 (from 상민)

## Key changes
- /place/:mapId/kakao/:kakaoId  API 추가
    - 지도에 등록되지 않은 장소도 조회할 수 있도록 kakaoId로 받음
    - 지도에 등록 O placeResponse,  X kakaoResponse
- MapRoleGuard에  mapId 받아올 때, request.param.mapId 추가

## To reviewers


## Screenshots
