### PR TITLE
Feat: Add User's ProfileImage

### DIFF
--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -38,6 +38,9 @@ export class User {
   @Property({ type: 'string', default: null })
   nickname: string | null = null;
 
+  @Property({ type: 'string', default: null })
+  profileImage: string | null = null;
+
   @Property()
   kakaoAccessToken: string;
 

--- a/src/migrations/.snapshot-korrk-stage.json
+++ b/src/migrations/.snapshot-korrk-stage.json
@@ -467,6 +467,16 @@
           "default": "null",
           "mappedType": "string"
         },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "default": "null",
+          "mappedType": "string"
+        },
         "kakao_access_token": {
           "name": "kakao_access_token",
           "type": "varchar(255)",
@@ -1012,7 +1022,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "default": "'WRITE'",
+          "default": "'READ'",
           "mappedType": "string"
         },
         "expires_at": {

--- a/src/migrations/Migration20240904080344.ts
+++ b/src/migrations/Migration20240904080344.ts
@@ -1,0 +1,27 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20240904080344 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'alter table "user" add column "profile_image" varchar(255) null;',
+    );
+
+    this.addSql(
+      'alter table "invite_link" alter column "map_role" type varchar(255) using ("map_role"::varchar(255));',
+    );
+    this.addSql(
+      'alter table "invite_link" alter column "map_role" set default \'READ\';',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "user" drop column "profile_image";');
+
+    this.addSql(
+      'alter table "invite_link" alter column "map_role" type varchar(255) using ("map_role"::varchar(255));',
+    );
+    this.addSql(
+      'alter table "invite_link" alter column "map_role" set default \'WRITE\';',
+    );
+  }
+}

--- a/src/user/dtos/update-user.dto.ts
+++ b/src/user/dtos/update-user.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
 
 import { User, UserRoleValueType } from 'src/entities';
 
@@ -16,12 +16,20 @@ export class UpdateUserDto implements Partial<User> {
 
   @IsOptional()
   kakaoRefreshToken?: string;
+
+  @IsOptional()
+  profileImage?: string;
 }
 
 export class UpdateUserRequestDto implements Partial<User> {
-  @ApiProperty({ required: true })
-  @IsNotEmpty()
+  @ApiProperty({ required: false })
+  @IsOptional()
   @IsString()
   @MaxLength(6, { message: '닉네임은 최대 6글자까지 입력할 수 있어요.' })
   nickname: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  profileImage?: string;
 }

--- a/src/user/dtos/user-response.dto.ts
+++ b/src/user/dtos/user-response.dto.ts
@@ -15,6 +15,8 @@ export class UserResponseDto implements Partial<Omit<User, 'userMap'>> {
   @ApiProperty()
   providerId: string;
 
+  @ApiProperty()
+  profileImage: string;
   // @ApiProperty({ enum: UserRole })
   // role: UserRoleValueType;
 
@@ -23,6 +25,7 @@ export class UserResponseDto implements Partial<Omit<User, 'userMap'>> {
     this.nickname = user.nickname;
     this.provider = user.provider;
     this.providerId = user.providerId;
+    this.profileImage = user.profileImage;
     // this.role = user.role;
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -54,9 +54,6 @@ export class UserService {
     Object.assign(user, updateUserDto); // Assign DTO properties to user entity
     await this.userRepository.persistAndFlush(user); // Persist changes
     return user;
-    // (wrap(user) as any).assign(updateUserDto);
-    // await this.userRepository.persistAndFlush(user);
-    // return user;
   }
 
   remove(id: number) {


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Refactoring (no functional changes, no api changes)

## For what purpose

- 유저의 프로필이미지 필드 추가
- 기본값 null
- PATCH /users/me API를 통해 수정 가능
- 
## Key changes

- 유저의 프로필이미지 필드 추가
- 기본값 null
- PATCH /users/me API를 통해 수정 가능

## To reviewers

- 이미지 업로드하는 API 필요함...

## Screenshots
